### PR TITLE
Fix colorama windows

### DIFF
--- a/pymon/main.py
+++ b/pymon/main.py
@@ -30,7 +30,8 @@ def main():
     def handle_event(event):
 
         global process
-
+        
+        os.system("pymon restarting...")
         print(Fore.GREEN + "[pymon] restarting due to changes..." + Style.RESET_ALL)
 
         if arguments.force_kill:
@@ -46,9 +47,11 @@ def main():
     observer.schedule(event_handler, os.getcwd(), recursive=True)
 
     observer.start()
-
+    
+    os.system("pymon watching directory")
     print(Fore.YELLOW + Style.BRIGHT + "\n[pymon] watching directory" + Style.RESET_ALL)
 
+    os.system(f"pymon starting {arguments.filename}")
     process = subprocess.Popen([sys.executable, arguments.filename])
     print(Fore.GREEN + f"[pymon] starting {arguments.filename}" + Style.RESET_ALL)
 
@@ -60,4 +63,5 @@ def main():
     observer.join()
 
 if __name__ == "__main__":
+    os.system("pymon")
     main()

--- a/pymon/main.py
+++ b/pymon/main.py
@@ -3,12 +3,12 @@ import sys
 import time
 import argparse
 import subprocess
-import platform
-from colorama import Fore, Style
+from colorama import Fore, Style, init
 from watchdog.observers import Observer
 from watchdog.events import PatternMatchingEventHandler
 
 def main():
+    init()
     """CLI Command to execute the provided script with pymon"""
 
     # CLI Argument Parser
@@ -32,7 +32,6 @@ def main():
 
         global process
         
-        if platform.system() == 'Windows': os.system("title pymon restarting...")
         print(Fore.GREEN + "[pymon] restarting due to changes..." + Style.RESET_ALL)
 
         if arguments.force_kill:
@@ -49,10 +48,8 @@ def main():
 
     observer.start()
     
-    if platform.system() == 'Windows': os.system("title pymon watching directory")
     print(Fore.YELLOW + Style.BRIGHT + "\n[pymon] watching directory" + Style.RESET_ALL)
 
-    if platform.system() == 'Windows': os.system(f"title pymon starting {arguments.filename}")
     process = subprocess.Popen([sys.executable, arguments.filename])
     print(Fore.GREEN + f"[pymon] starting {arguments.filename}" + Style.RESET_ALL)
 
@@ -64,5 +61,4 @@ def main():
     observer.join()
 
 if __name__ == "__main__":
-    if platform.system() == 'Windows': os.system("title pymon")
     main()

--- a/pymon/main.py
+++ b/pymon/main.py
@@ -8,8 +8,8 @@ from watchdog.observers import Observer
 from watchdog.events import PatternMatchingEventHandler
 
 def main():
-    init()
     """CLI Command to execute the provided script with pymon"""
+    init()
 
     # CLI Argument Parser
     parser = argparse.ArgumentParser(
@@ -31,7 +31,6 @@ def main():
     def handle_event(event):
 
         global process
-        
         print(Fore.GREEN + "[pymon] restarting due to changes..." + Style.RESET_ALL)
 
         if arguments.force_kill:
@@ -42,17 +41,12 @@ def main():
         process = subprocess.Popen([sys.executable, arguments.filename])
 
     event_handler.on_any_event = handle_event
-
     observer = Observer()
     observer.schedule(event_handler, os.getcwd(), recursive=True)
-
     observer.start()
-    
     print(Fore.YELLOW + Style.BRIGHT + "\n[pymon] watching directory" + Style.RESET_ALL)
-
     process = subprocess.Popen([sys.executable, arguments.filename])
     print(Fore.GREEN + f"[pymon] starting {arguments.filename}" + Style.RESET_ALL)
-
     try:
         while True:
             time.sleep(2)

--- a/pymon/main.py
+++ b/pymon/main.py
@@ -41,17 +41,21 @@ def main():
         process = subprocess.Popen([sys.executable, arguments.filename])
 
     event_handler.on_any_event = handle_event
+    
     observer = Observer()
     observer.schedule(event_handler, os.getcwd(), recursive=True)
     observer.start()
+    
     print(Fore.YELLOW + Style.BRIGHT + "\n[pymon] watching directory" + Style.RESET_ALL)
     process = subprocess.Popen([sys.executable, arguments.filename])
     print(Fore.GREEN + f"[pymon] starting {arguments.filename}" + Style.RESET_ALL)
+    
     try:
         while True:
             time.sleep(2)
     except KeyboardInterrupt:
         observer.stop()
+        
     observer.join()
 
 if __name__ == "__main__":

--- a/pymon/main.py
+++ b/pymon/main.py
@@ -3,6 +3,7 @@ import sys
 import time
 import argparse
 import subprocess
+import platform
 from colorama import Fore, Style
 from watchdog.observers import Observer
 from watchdog.events import PatternMatchingEventHandler
@@ -31,7 +32,7 @@ def main():
 
         global process
         
-        os.system("pymon restarting...")
+        if platform.system() == 'Windows': os.system("title pymon restarting...")
         print(Fore.GREEN + "[pymon] restarting due to changes..." + Style.RESET_ALL)
 
         if arguments.force_kill:
@@ -48,10 +49,10 @@ def main():
 
     observer.start()
     
-    os.system("pymon watching directory")
+    if platform.system() == 'Windows': os.system("title pymon watching directory")
     print(Fore.YELLOW + Style.BRIGHT + "\n[pymon] watching directory" + Style.RESET_ALL)
 
-    os.system(f"pymon starting {arguments.filename}")
+    if platform.system() == 'Windows': os.system(f"title pymon starting {arguments.filename}")
     process = subprocess.Popen([sys.executable, arguments.filename])
     print(Fore.GREEN + f"[pymon] starting {arguments.filename}" + Style.RESET_ALL)
 
@@ -63,5 +64,5 @@ def main():
     observer.join()
 
 if __name__ == "__main__":
-    os.system("pymon")
+    if platform.system() == 'Windows': os.system("title pymon")
     main()


### PR DESCRIPTION
In Windows, sometimes the Colorama module works properly, but the powershell/cmd doesn't accept the ascii color codes.

Without os.system("title ...")
![Without](https://user-images.githubusercontent.com/61649925/109279421-bb904880-783f-11eb-8471-c7b3219f92f0.gif)

With:
![With](https://user-images.githubusercontent.com/61649925/109283713-1e381300-7845-11eb-93b7-cffaafc15ca2.gif)

