### PR TITLE
add ignore-patterns

### DIFF
--- a/pymon/main.py
+++ b/pymon/main.py
@@ -25,6 +25,16 @@ parser.add_argument(
 )
 
 parser.add_argument(
+    "-i",
+    "--ignore-patterns",
+    type=str,
+    help="ignores event paths with these patterns. use once for each pattern",
+    action="append",
+    default=[".#*.py"],
+    metavar="ignore patterns",
+)
+
+parser.add_argument(
     "-w",
     "--watch",
     type=str,

--- a/pymon/monitor.py
+++ b/pymon/monitor.py
@@ -21,13 +21,16 @@ class Monitor:
             ".py" if not arguments.filename.endswith(".py") else ""
         )
         self.patterns = arguments.patterns
+        self.ignore_patterns = arguments.ignore_patterns
         self.args = arguments.args
         self.watch = arguments.watch
         self.debug = arguments.debug
 
         self.process = None
 
-        self.event_handler = PatternMatchingEventHandler(patterns=self.patterns)
+        self.event_handler = PatternMatchingEventHandler(
+            patterns=self.patterns, ignore_patterns=self.ignore_patterns
+        )
         self.event_handler.on_modified = self._handle_event
         self.event_handler.on_created = self._handle_event
         self.event_handler.on_deleted = self._handle_event
@@ -39,6 +42,9 @@ class Monitor:
     def start(self):
         log(Color.YELLOW, f"watching path: {self.watch}")
         log(Color.YELLOW, f"watching patterns: {', '.join(self.patterns)}")
+        log(
+            Color.YELLOW, f"watching ignore-patterns: {', '.join(self.ignore_patterns)}"
+        )
         log(Color.YELLOW, "enter 'rs' to restart or 'stop' to terminate")
 
         self.observer.start()


### PR DESCRIPTION
Add --ignore-patterns parameter.
Some editor like emacs create temporary files while editing called `.#{filename}.py` which triggers pymon to reload a few times before even saving the file.

This PR adds a parameter --ignore-paterns to avoid reloading prematurely.