### PR TITLE
fix: wait process terminating after send SIGTERM signal

### DIFF
--- a/pymon/monitor.py
+++ b/pymon/monitor.py
@@ -160,4 +160,5 @@ class Monitor:
 
         if self.process:
             self.process.terminate()
+            self.process.wait()
             self.process = None


### PR DESCRIPTION
without `wait` it was try to assign same server port