### PR TITLE
Release 2.2.0: config files, version flag, debounce, CI, tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## 2.2.0
+- Added `--version` / `-V` to print the installed version.
+- Added config file support (`.pymonrc`, `pymon.json`).
+- Added GitHub Actions CI to run tests on push/PR.
+- Expanded docs: config file usage, test instructions.
+
+## 2.1.0
+- Refreshed codebase and options (watch/ignore/exec/debug/clean).
+- Added colored logging and command input helpers (`rs`, `stop`).
+
+## 2.0.x and earlier
+- Initial rewrite with auto-reload for Python scripts and shell commands.
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Kevin Thomas
+Copyright (c) 2026 Kevin Thomas
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,41 +1,32 @@
 # py-mon [![](https://img.shields.io/pypi/v/py-mon?color=3776AB&logo=python&style=for-the-badge)](https://pypi.org/project/py-mon/) [![](https://img.shields.io/pypi/dm/py-mon?color=3776AB&logo=python&style=for-the-badge)](https://pypi.org/project/py-mon/)
 A modern, easy-to-use package to automatically restart a Python application when file changes are detected!
 
-## Quickstart
-I wanted to make this package as easy as possible to use. Here's a quick start, it's all you'll need 😼
-
-### Installation
-```
+## Quickstart (10s)
+```bash
 pip install -U py-mon
+pymon app.py
 ```
-### Execution
-```
-pymon filename.py
-```
+Zero-config reloads for Python files by default.
 
-That's pretty much it! 😌 
+### Why py-mon?
+- Works for Python files or any shell command (`-x "npm run dev"`).
+- Simple patterns for watch/ignore; sane defaults.
+- Clean/quiet mode available when you don’t want prompts.
 
-If you have a more sophisticated use-case, here are the available command line options:
-- `--watch` (`-w`) to specify paths or patterns to watch. Examples: `src/*.py`, `data/**/*.json`. Default: `*.py`
-- `--ignore` (`-i`) to specify patterns of files/paths to ignore. Use once for each pattern.
-- `--exec` (`-x`) to execute a shell command instead of running a Python file.
-- `--debug` (`-d`) to log detected file changes to the terminal.
-- `--clean` (`-c`) to run pymon in clean mode (no logs, no commands).
-
-#### Examples:
-- `pymon test.py -w "*.json"` will monitor changes in Python (default) and JSON files in the current directory
-- `pymon test.py -w "src/*.py" -w "data/*.json"` will monitor Python files in the src directory and JSON files in the data directory
-- `pymon test.py -i "*.log" -i "*__pycache__*"` will ignore changes in log files and __pycache__ directories
-- `pymon "python3 -m http.server" -x` will run the server and restart it when files change
-- `pymon "npm run dev" -x -w "src/*.js" -w "src/*.jsx"` will run a Node.js dev server and monitor JavaScript files
+### Core flags
+- `-w / --watch <pattern>`: what to watch (default `*.py`).
+- `-i / --ignore <pattern>`: what to ignore.
+- `-x / --exec`: run a shell command instead of `python <file>`.
+- `-d / --debug`: print changed paths.
+- `-c / --clean`: no logs, no stdin commands.
 
 ### Command Input
 When running pymon, you can use these commands:
 - Type `rs` to manually restart the process
 - Type `stop` to terminate pymon
 
-### Config File
-You can create a `.pymonrc` or `pymon.json` file in your project root to define default settings:
+### Optional Config File
+Put a `.pymonrc` or `pymon.json` in your project root to keep team settings consistent:
 
 ```json
 {
@@ -43,18 +34,12 @@ You can create a `.pymonrc` or `pymon.json` file in your project root to define 
   "ignore": ["*__pycache__*", "*.log"],
   "debug": false,
   "clean": false,
-  "exec": false
+  "exec": false,
+  "delay": 250
 }
 ```
 
 Command line arguments will always override config file settings.
-
-### Tests
-Run the test suite locally with pytest:
-```
-pip install -e ".[dev]"
-pytest
-```
 
 Anyway that's basically it! Thanks for everything, I would appreciate it if you could leave a follow or star this repository ❣️ If you have any feature requests, read below!
 
@@ -67,7 +52,9 @@ If you find any issues with the package or in the code, please [create an issue 
 ### Fix/Edit Content
 If you want to contribute to this package, fork the repository, clone it, make your changes and then [proceed to create a pull request here](https://github.com/kevinjosethomas/py-mon/pulls)
 
-## Inspiration
-Back when I was 13, I spent a lot of time developing discord bots and it was a hassle to constantly `Ctrl+C` and then run the bot again on my terminal. Since I had just gotten started with web development back then, I decided to make something like  [nodemon](https://github.com/remy/nodemon) but for Python so I randomly created this package one evening! I looked back at it a few weeks ago (I'm now 16) and realized over a thousand people download it every month so I quickly rewrote it (v2) to clean it up and add some new features!
-
-![](https://media1.tenor.com/images/5d6cd0c6b0a0ae3c193e766fb8f1ed1f/tenor.gif?itemid=14057131)
+### Tests
+Run the test suite locally with pytest:
+```
+pip install -e ".[dev]"
+pytest
+```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,21 @@ When running pymon, you can use these commands:
 - Type `rs` to manually restart the process
 - Type `stop` to terminate pymon
 
+### Config File
+You can create a `.pymonrc` or `pymon.json` file in your project root to define default settings:
+
+```json
+{
+  "watch": ["*.py", "config/*.yaml"],
+  "ignore": ["*__pycache__*", "*.log"],
+  "debug": false,
+  "clean": false,
+  "exec": false
+}
+```
+
+Command line arguments will always override config file settings.
+
 Anyway that's basically it! Thanks for everything, I would appreciate it if you could leave a follow or star this repository ❣️ If you have any feature requests, read below!
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ You can create a `.pymonrc` or `pymon.json` file in your project root to define 
 
 Command line arguments will always override config file settings.
 
+### Tests
+Run the test suite locally with pytest:
+```
+pip install -e ".[dev]"
+pytest
+```
+
 Anyway that's basically it! Thanks for everything, I would appreciate it if you could leave a follow or star this repository ❣️ If you have any feature requests, read below!
 
 ## Contributing

--- a/pymon/__init__.py
+++ b/pymon/__init__.py
@@ -1,3 +1,3 @@
 from .logger import *
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"

--- a/pymon/__init__.py
+++ b/pymon/__init__.py
@@ -1,1 +1,3 @@
 from .logger import *
+
+__version__ = "2.1.0"

--- a/pymon/main.py
+++ b/pymon/main.py
@@ -22,6 +22,9 @@ def load_config():
             except json.JSONDecodeError as e:
                 log(Color.RED, f"Error parsing {config_name}: {e}")
                 return {}, None
+            except OSError as e:
+                log(Color.RED, f"Error reading {config_name}: {e}")
+                return {}, None
     return {}, None
 
 

--- a/pymon/main.py
+++ b/pymon/main.py
@@ -1,8 +1,50 @@
+import json
 import time
 import argparse
 import colorama
+from pathlib import Path
 
 from .monitor import Monitor
+from .logger import log, Color
+
+CONFIG_FILES = [".pymonrc", "pymon.json"]
+
+
+def load_config():
+    """Load configuration from .pymonrc or pymon.json if present."""
+    for config_name in CONFIG_FILES:
+        config_path = Path(config_name)
+        if config_path.exists():
+            try:
+                with open(config_path, "r") as f:
+                    config = json.load(f)
+                return config, config_name
+            except json.JSONDecodeError as e:
+                log(Color.RED, f"Error parsing {config_name}: {e}")
+                return {}, None
+    return {}, None
+
+
+def merge_config(args, config):
+    """Merge config file settings with command line arguments. CLI takes precedence."""
+
+    if args.watch is None:
+        args.watch = config.get("watch", ["*.py"])
+
+    if not args.ignore:
+        args.ignore = config.get("ignore", [])
+
+    if not args.debug:
+        args.debug = config.get("debug", False)
+
+    if not args.clean:
+        args.clean = config.get("clean", False)
+
+    if not args.exec:
+        args.exec = config.get("exec", False)
+
+    return args
+
 
 parser = argparse.ArgumentParser(
     prog="pymon",
@@ -21,7 +63,7 @@ parser.add_argument(
     type=str,
     help="paths/patterns to watch (e.g., 'src/*.py', 'data/**/*.json'). use once for each path/pattern. default is '*.py'",
     action="append",
-    default=["*.py"],
+    default=None,
     metavar="path_pattern",
 )
 
@@ -61,6 +103,11 @@ parser.add_argument(
 def main():
     colorama.init()
     arguments = parser.parse_args()
+
+    config, config_name = load_config()
+    if config and not arguments.clean:
+        log(Color.CYAN, f"using config from {config_name}")
+    arguments = merge_config(arguments, config)
 
     monitor = Monitor(arguments)
     monitor.start()

--- a/pymon/main.py
+++ b/pymon/main.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from .monitor import Monitor
 from .logger import log, Color
+from . import __version__
 
 CONFIG_FILES = [".pymonrc", "pymon.json"]
 
@@ -51,6 +52,14 @@ def merge_config(args, config):
 
 parser = argparse.ArgumentParser(
     prog="pymon",
+)
+
+parser.add_argument(
+    "-V",
+    "--version",
+    action="version",
+    version=f"%(prog)s {__version__}",
+    help="show the py-mon version and exit",
 )
 
 parser.add_argument(

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts = -v --tb=short
+

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="py-mon",
-    version="2.1.0",
+    version="2.2.0",
     author="kevinjosethomas",
     author_email="kevin.jt2007@gmail.com",
     description="🔁 Automatically restart application when file changes are detected; made for development",

--- a/setup.py
+++ b/setup.py
@@ -26,4 +26,9 @@ setuptools.setup(
         "colorama",
         "watchdog",
     ],
+    extras_require={
+        "dev": [
+            "pytest>=7.0.0",
+        ],
+    },
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 import pytest
 from pymon.main import parser
+from pymon import __version__
 
 
 class TestCLIArguments:
@@ -109,4 +110,22 @@ class TestCLIArguments:
         args = parser.parse_args(["python -m http.server", "-x"])
         assert args.command == "python -m http.server"
         assert args.exec is True
+
+    def test_version_flag(self, capsys):
+        """Should print version and exit."""
+        with pytest.raises(SystemExit) as excinfo:
+            parser.parse_args(["--version"])
+
+        assert excinfo.value.code == 0
+        out = capsys.readouterr().out
+        assert __version__ in out
+
+    def test_version_short_flag(self, capsys):
+        """Should print version with short flag and exit."""
+        with pytest.raises(SystemExit) as excinfo:
+            parser.parse_args(["-V"])
+
+        assert excinfo.value.code == 0
+        out = capsys.readouterr().out
+        assert __version__ in out
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,112 @@
+"""Tests for CLI argument parsing."""
+
+import pytest
+from pymon.main import parser
+
+
+class TestCLIArguments:
+    """Tests for command line argument parsing."""
+
+    def test_command_required(self):
+        """Should require command argument."""
+        with pytest.raises(SystemExit):
+            parser.parse_args([])
+
+    def test_command_parsed(self):
+        """Should parse command argument."""
+        args = parser.parse_args(["app.py"])
+        assert args.command == "app.py"
+
+    def test_watch_default_none(self):
+        """Should have None as default watch (merged later)."""
+        args = parser.parse_args(["app.py"])
+        assert args.watch is None
+
+    def test_watch_single(self):
+        """Should parse single watch pattern."""
+        args = parser.parse_args(["app.py", "-w", "*.json"])
+        assert args.watch == ["*.json"]
+
+    def test_watch_multiple(self):
+        """Should parse multiple watch patterns."""
+        args = parser.parse_args(["app.py", "-w", "*.py", "-w", "*.json"])
+        assert args.watch == ["*.py", "*.json"]
+
+    def test_watch_long_form(self):
+        """Should parse --watch long form."""
+        args = parser.parse_args(["app.py", "--watch", "src/*.py"])
+        assert args.watch == ["src/*.py"]
+
+    def test_ignore_default_empty(self):
+        """Should have empty list as default ignore."""
+        args = parser.parse_args(["app.py"])
+        assert args.ignore == []
+
+    def test_ignore_single(self):
+        """Should parse single ignore pattern."""
+        args = parser.parse_args(["app.py", "-i", "*.log"])
+        assert args.ignore == ["*.log"]
+
+    def test_ignore_multiple(self):
+        """Should parse multiple ignore patterns."""
+        args = parser.parse_args(["app.py", "-i", "*.log", "-i", "*__pycache__*"])
+        assert args.ignore == ["*.log", "*__pycache__*"]
+
+    def test_debug_default_false(self):
+        """Should have False as default debug."""
+        args = parser.parse_args(["app.py"])
+        assert args.debug is False
+
+    def test_debug_flag(self):
+        """Should set debug to True with -d flag."""
+        args = parser.parse_args(["app.py", "-d"])
+        assert args.debug is True
+
+    def test_debug_long_form(self):
+        """Should set debug with --debug."""
+        args = parser.parse_args(["app.py", "--debug"])
+        assert args.debug is True
+
+    def test_clean_default_false(self):
+        """Should have False as default clean."""
+        args = parser.parse_args(["app.py"])
+        assert args.clean is False
+
+    def test_clean_flag(self):
+        """Should set clean to True with -c flag."""
+        args = parser.parse_args(["app.py", "-c"])
+        assert args.clean is True
+
+    def test_exec_default_false(self):
+        """Should have False as default exec."""
+        args = parser.parse_args(["app.py"])
+        assert args.exec is False
+
+    def test_exec_flag(self):
+        """Should set exec to True with -x flag."""
+        args = parser.parse_args(["app.py", "-x"])
+        assert args.exec is True
+
+    def test_combined_flags(self):
+        """Should parse multiple flags together."""
+        args = parser.parse_args([
+            "npm run dev",
+            "-x",
+            "-d",
+            "-w", "*.js",
+            "-w", "*.jsx",
+            "-i", "node_modules",
+        ])
+        
+        assert args.command == "npm run dev"
+        assert args.exec is True
+        assert args.debug is True
+        assert args.watch == ["*.js", "*.jsx"]
+        assert args.ignore == ["node_modules"]
+
+    def test_shell_command_with_exec(self):
+        """Should accept shell commands with exec mode."""
+        args = parser.parse_args(["python -m http.server", "-x"])
+        assert args.command == "python -m http.server"
+        assert args.exec is True
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,211 @@
+"""Tests for config file loading and merging."""
+
+import json
+import pytest
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import patch, mock_open
+
+from pymon.main import load_config, merge_config
+
+
+class TestLoadConfig:
+    """Tests for the load_config function."""
+
+    def test_load_pymonrc(self, tmp_path, monkeypatch):
+        """Should load config from .pymonrc file."""
+        monkeypatch.chdir(tmp_path)
+
+        config_data = {"watch": ["*.py", "*.json"], "debug": True}
+        config_file = tmp_path / ".pymonrc"
+        config_file.write_text(json.dumps(config_data))
+
+        config, name = load_config()
+
+        assert name == ".pymonrc"
+        assert config == config_data
+
+    def test_load_pymon_json(self, tmp_path, monkeypatch):
+        """Should load config from pymon.json file."""
+        monkeypatch.chdir(tmp_path)
+
+        config_data = {"watch": ["src/*.py"], "ignore": ["*.log"]}
+        config_file = tmp_path / "pymon.json"
+        config_file.write_text(json.dumps(config_data))
+
+        config, name = load_config()
+
+        assert name == "pymon.json"
+        assert config == config_data
+
+    def test_pymonrc_takes_priority(self, tmp_path, monkeypatch):
+        """Should prefer .pymonrc over pymon.json when both exist."""
+        monkeypatch.chdir(tmp_path)
+
+        pymonrc_data = {"watch": ["from_pymonrc"]}
+        pymon_json_data = {"watch": ["from_pymon_json"]}
+
+        (tmp_path / ".pymonrc").write_text(json.dumps(pymonrc_data))
+        (tmp_path / "pymon.json").write_text(json.dumps(pymon_json_data))
+
+        config, name = load_config()
+
+        assert name == ".pymonrc"
+        assert config["watch"] == ["from_pymonrc"]
+
+    def test_no_config_file(self, tmp_path, monkeypatch):
+        """Should return empty config when no config file exists."""
+        monkeypatch.chdir(tmp_path)
+
+        config, name = load_config()
+
+        assert config == {}
+        assert name is None
+
+    def test_invalid_json(self, tmp_path, monkeypatch, capsys):
+        """Should handle invalid JSON gracefully."""
+        monkeypatch.chdir(tmp_path)
+
+        config_file = tmp_path / ".pymonrc"
+        config_file.write_text("{ invalid json }")
+
+        config, name = load_config()
+
+        assert config == {}
+        assert name is None
+
+    def test_empty_config_file(self, tmp_path, monkeypatch):
+        """Should handle empty config object."""
+        monkeypatch.chdir(tmp_path)
+
+        config_file = tmp_path / ".pymonrc"
+        config_file.write_text("{}")
+
+        config, name = load_config()
+
+        assert config == {}
+        assert name == ".pymonrc"
+
+
+class TestMergeConfig:
+    """Tests for the merge_config function."""
+
+    def create_args(self, **kwargs):
+        """Helper to create a Namespace with default values."""
+        defaults = {
+            "command": "app.py",
+            "watch": None,
+            "ignore": [],
+            "debug": False,
+            "clean": False,
+            "exec": False,
+        }
+        defaults.update(kwargs)
+        return Namespace(**defaults)
+
+    def test_config_sets_watch(self):
+        """Config should set watch patterns when CLI doesn't specify."""
+        args = self.create_args(watch=None)
+        config = {"watch": ["src/*.py", "*.json"]}
+
+        result = merge_config(args, config)
+
+        assert result.watch == ["src/*.py", "*.json"]
+
+    def test_cli_watch_overrides_config(self):
+        """CLI watch should override config watch."""
+        args = self.create_args(watch=["cli/*.py"])
+        config = {"watch": ["config/*.py"]}
+
+        result = merge_config(args, config)
+
+        assert result.watch == ["cli/*.py"]
+
+    def test_default_watch_when_no_config(self):
+        """Should use default *.py when no CLI or config watch."""
+        args = self.create_args(watch=None)
+        config = {}
+
+        result = merge_config(args, config)
+
+        assert result.watch == ["*.py"]
+
+    def test_config_sets_ignore(self):
+        """Config should set ignore patterns when CLI doesn't specify."""
+        args = self.create_args(ignore=[])
+        config = {"ignore": ["*.log", "*__pycache__*"]}
+
+        result = merge_config(args, config)
+
+        assert result.ignore == ["*.log", "*__pycache__*"]
+
+    def test_cli_ignore_overrides_config(self):
+        """CLI ignore should override config ignore."""
+        args = self.create_args(ignore=["cli_ignore"])
+        config = {"ignore": ["config_ignore"]}
+
+        result = merge_config(args, config)
+
+        assert result.ignore == ["cli_ignore"]
+
+    def test_config_sets_debug(self):
+        """Config should set debug when CLI doesn't specify."""
+        args = self.create_args(debug=False)
+        config = {"debug": True}
+
+        result = merge_config(args, config)
+
+        assert result.debug is True
+
+    def test_cli_debug_overrides_config(self):
+        """CLI debug should override config debug."""
+        args = self.create_args(debug=True)
+        config = {"debug": False}
+
+        result = merge_config(args, config)
+
+        assert result.debug is True
+
+    def test_config_sets_clean(self):
+        """Config should set clean when CLI doesn't specify."""
+        args = self.create_args(clean=False)
+        config = {"clean": True}
+
+        result = merge_config(args, config)
+
+        assert result.clean is True
+
+    def test_config_sets_exec(self):
+        """Config should set exec when CLI doesn't specify."""
+        args = self.create_args(exec=False)
+        config = {"exec": True}
+
+        result = merge_config(args, config)
+
+        assert result.exec is True
+
+    def test_empty_config_uses_defaults(self):
+        """Empty config should result in default values."""
+        args = self.create_args()
+        config = {}
+
+        result = merge_config(args, config)
+
+        assert result.watch == ["*.py"]
+        assert result.ignore == []
+        assert result.debug is False
+        assert result.clean is False
+        assert result.exec is False
+
+    def test_partial_config(self):
+        """Should handle partial config with some fields."""
+        args = self.create_args()
+        config = {"watch": ["*.py", "*.json"], "debug": True}
+
+        result = merge_config(args, config)
+
+        assert result.watch == ["*.py", "*.json"]
+        assert result.debug is True
+        assert result.ignore == []
+        assert result.clean is False
+        assert result.exec is False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -62,6 +62,19 @@ class TestLoadConfig:
         assert config == {}
         assert name is None
 
+    def test_unreadable_config_file(self, tmp_path, monkeypatch):
+        """Should handle unreadable config file gracefully."""
+        monkeypatch.chdir(tmp_path)
+
+        config_file = tmp_path / ".pymonrc"
+        config_file.write_text("{}")
+
+        with patch("builtins.open", side_effect=PermissionError("denied")):
+            config, name = load_config()
+
+        assert config == {}
+        assert name is None
+
     def test_invalid_json(self, tmp_path, monkeypatch, capsys):
         """Should handle invalid JSON gracefully."""
         monkeypatch.chdir(tmp_path)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,74 @@
+"""Tests for the logger module."""
+
+import pytest
+from unittest.mock import patch
+from colorama import Fore, Style
+
+from pymon.logger import log, Color
+
+
+class TestColor:
+    """Tests for Color class constants."""
+
+    def test_green_color(self):
+        """Should have green color defined."""
+        assert Color.GREEN == Fore.GREEN
+
+    def test_yellow_color(self):
+        """Should have yellow bright color defined."""
+        assert Color.YELLOW == Fore.YELLOW + Style.BRIGHT
+
+    def test_red_color(self):
+        """Should have red color defined."""
+        assert Color.RED == Fore.RED
+
+    def test_cyan_color(self):
+        """Should have cyan color defined."""
+        assert Color.CYAN == Fore.CYAN
+
+
+class TestLog:
+    """Tests for the log function."""
+
+    def test_log_formats_message(self, capsys):
+        """Should format message with pymon prefix."""
+        log(Color.GREEN, "test message")
+        
+        captured = capsys.readouterr()
+        assert "[pymon]" in captured.out
+        assert "test message" in captured.out
+
+    def test_log_includes_color(self, capsys):
+        """Should include color codes in output."""
+        log(Color.GREEN, "test")
+        
+        captured = capsys.readouterr()
+        assert Fore.GREEN in captured.out
+
+    def test_log_resets_style(self, capsys):
+        """Should reset style after message."""
+        log(Color.RED, "test")
+        
+        captured = capsys.readouterr()
+        assert Style.RESET_ALL in captured.out
+
+    def test_log_different_colors(self, capsys):
+        """Should work with different colors."""
+        log(Color.GREEN, "green")
+        log(Color.YELLOW, "yellow")
+        log(Color.RED, "red")
+        log(Color.CYAN, "cyan")
+        
+        captured = capsys.readouterr()
+        assert "green" in captured.out
+        assert "yellow" in captured.out
+        assert "red" in captured.out
+        assert "cyan" in captured.out
+
+    def test_log_empty_message(self, capsys):
+        """Should handle empty message."""
+        log(Color.GREEN, "")
+        
+        captured = capsys.readouterr()
+        assert "[pymon]" in captured.out
+

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,296 @@
+"""Tests for the Monitor class."""
+
+import pytest
+from argparse import Namespace
+from unittest.mock import Mock, patch, MagicMock
+
+from pymon.monitor import Monitor
+
+
+class TestMonitorPathParsing:
+    """Tests for path pattern parsing in Monitor."""
+
+    def create_monitor(self, **kwargs):
+        """Helper to create a Monitor with default args."""
+        defaults = {
+            "command": "app.py",
+            "watch": ["*.py"],
+            "ignore": [],
+            "debug": False,
+            "clean": False,
+            "exec": False,
+        }
+        defaults.update(kwargs)
+        args = Namespace(**defaults)
+        
+        with patch.object(Monitor, '__init__', lambda self, args: None):
+            monitor = Monitor.__new__(Monitor)
+            monitor.command = args.command
+            monitor.debug = args.debug
+            monitor.clean = args.clean
+            monitor.exec_mode = args.exec
+            monitor.ignore_patterns = args.ignore
+        
+        return monitor, args
+
+    def test_parse_simple_pattern(self):
+        """Should parse simple glob pattern."""
+        monitor, _ = self.create_monitor()
+        
+        directory, pattern = monitor._parse_watch_path("*.py")
+        
+        assert directory == "."
+        assert pattern == "*.py"
+
+    def test_parse_directory_pattern(self):
+        """Should parse pattern with directory."""
+        monitor, _ = self.create_monitor()
+        
+        directory, pattern = monitor._parse_watch_path("src/*.py")
+        
+        assert directory == "src"
+        assert pattern == "*.py"
+
+    def test_parse_nested_directory_pattern(self):
+        """Should parse pattern with nested directories."""
+        monitor, _ = self.create_monitor()
+        
+        directory, pattern = monitor._parse_watch_path("src/lib/*.py")
+        
+        assert directory == "src/lib"
+        assert pattern == "*.py"
+
+    def test_parse_recursive_pattern(self):
+        """Should parse recursive glob pattern."""
+        monitor, _ = self.create_monitor()
+        
+        directory, pattern = monitor._parse_watch_path("src/**/*.py")
+        
+        assert directory == "src"
+        assert pattern == "**/*.py"
+
+    def test_parse_plain_directory(self):
+        """Should handle plain directory without glob."""
+        monitor, _ = self.create_monitor()
+        
+        directory, pattern = monitor._parse_watch_path("src")
+        
+        assert directory == "src"
+        assert pattern == "*"
+
+    def test_parse_question_mark_glob(self):
+        """Should handle ? glob character."""
+        monitor, _ = self.create_monitor()
+        
+        directory, pattern = monitor._parse_watch_path("src/file?.py")
+        
+        assert directory == "src"
+        assert pattern == "file?.py"
+
+    def test_parse_bracket_glob(self):
+        """Should handle [] glob characters."""
+        monitor, _ = self.create_monitor()
+        
+        directory, pattern = monitor._parse_watch_path("src/file[0-9].py")
+        
+        assert directory == "src"
+        assert pattern == "file[0-9].py"
+
+
+class TestMonitorPatternMatching:
+    """Tests for pattern matching in Monitor."""
+
+    def create_monitor(self):
+        """Helper to create a Monitor instance."""
+        with patch.object(Monitor, '__init__', lambda self, args: None):
+            monitor = Monitor.__new__(Monitor)
+        return monitor
+
+    def test_matches_simple_pattern(self):
+        """Should match simple glob pattern."""
+        monitor = self.create_monitor()
+        
+        assert monitor._matches_pattern("test.py", "*.py") is True
+        assert monitor._matches_pattern("test.js", "*.py") is False
+
+    def test_matches_directory_pattern(self):
+        """Should match pattern with directory."""
+        monitor = self.create_monitor()
+        
+        assert monitor._matches_pattern("src/test.py", "src/*.py") is True
+        assert monitor._matches_pattern("lib/test.py", "src/*.py") is False
+
+    def test_matches_pycache_pattern(self):
+        """Should match __pycache__ pattern."""
+        monitor = self.create_monitor()
+        
+        assert monitor._matches_pattern("src/__pycache__/test.pyc", "*__pycache__*") is True
+        assert monitor._matches_pattern("src/test.py", "*__pycache__*") is False
+
+    def test_matches_log_pattern(self):
+        """Should match log file pattern."""
+        monitor = self.create_monitor()
+        
+        assert monitor._matches_pattern("debug.log", "*.log") is True
+        assert monitor._matches_pattern("app.py", "*.log") is False
+
+
+class TestMonitorInitialization:
+    """Tests for Monitor initialization."""
+
+    def test_init_with_single_watch(self):
+        """Should initialize with a single watch pattern."""
+        args = Namespace(
+            command="app.py",
+            watch=["*.py"],
+            ignore=[],
+            debug=False,
+            clean=False,
+            exec=False,
+        )
+        
+        monitor = Monitor(args)
+        
+        assert monitor.command == "app.py"
+        assert (".", "*.py") in monitor.watch_items
+        assert monitor.debug is False
+        assert monitor.clean is False
+        assert monitor.exec_mode is False
+
+    def test_init_with_multiple_watch(self):
+        """Should initialize with multiple watch patterns."""
+        args = Namespace(
+            command="app.py",
+            watch=["*.py", "config/*.json"],
+            ignore=[],
+            debug=False,
+            clean=False,
+            exec=False,
+        )
+        
+        monitor = Monitor(args)
+        
+        assert len(monitor.watch_items) == 2
+        assert (".", "*.py") in monitor.watch_items
+        assert ("config", "*.json") in monitor.watch_items
+
+    def test_init_with_ignore_patterns(self):
+        """Should initialize with ignore patterns."""
+        args = Namespace(
+            command="app.py",
+            watch=["*.py"],
+            ignore=["*.log", "*__pycache__*"],
+            debug=False,
+            clean=False,
+            exec=False,
+        )
+        
+        monitor = Monitor(args)
+        
+        assert monitor.ignore_patterns == ["*.log", "*__pycache__*"]
+
+    def test_init_exec_mode(self):
+        """Should initialize in exec mode."""
+        args = Namespace(
+            command="npm run dev",
+            watch=["*.js"],
+            ignore=[],
+            debug=False,
+            clean=False,
+            exec=True,
+        )
+        
+        monitor = Monitor(args)
+        
+        assert monitor.exec_mode is True
+        assert monitor.command == "npm run dev"
+
+
+class TestMonitorProcessManagement:
+    """Tests for process start/stop/restart."""
+
+    def create_args(self, **kwargs):
+        """Helper to create args namespace."""
+        defaults = {
+            "command": "app.py",
+            "watch": ["*.py"],
+            "ignore": [],
+            "debug": False,
+            "clean": True,  # Use clean mode to suppress output
+            "exec": False,
+        }
+        defaults.update(kwargs)
+        return Namespace(**defaults)
+
+    @patch("pymon.monitor.subprocess.Popen")
+    def test_start_process_python_file(self, mock_popen):
+        """Should start Python file with python executable."""
+        args = self.create_args(command="app.py")
+        monitor = Monitor(args)
+        
+        monitor.start_process()
+        
+        mock_popen.assert_called_once()
+        call_args = mock_popen.call_args
+        assert "app.py" in call_args[0][0][1]
+
+    @patch("pymon.monitor.subprocess.Popen")
+    def test_start_process_adds_py_extension(self, mock_popen):
+        """Should add .py extension if missing."""
+        args = self.create_args(command="app")
+        monitor = Monitor(args)
+        
+        monitor.start_process()
+        
+        call_args = mock_popen.call_args
+        assert "app.py" in call_args[0][0][1]
+
+    @patch("pymon.monitor.subprocess.Popen")
+    def test_start_process_exec_mode(self, mock_popen):
+        """Should run shell command in exec mode."""
+        args = self.create_args(command="npm run dev", exec=True)
+        monitor = Monitor(args)
+        
+        monitor.start_process()
+        
+        mock_popen.assert_called_once_with("npm run dev", shell=True)
+
+    @patch("pymon.monitor.subprocess.Popen")
+    def test_stop_process(self, mock_popen):
+        """Should terminate running process."""
+        mock_process = Mock()
+        mock_popen.return_value = mock_process
+        
+        args = self.create_args()
+        monitor = Monitor(args)
+        monitor.start_process()
+        monitor.stop_process()
+        
+        mock_process.terminate.assert_called_once()
+        assert monitor.process is None
+
+    @patch("pymon.monitor.subprocess.Popen")
+    def test_stop_process_when_none(self, mock_popen):
+        """Should handle stop when no process is running."""
+        args = self.create_args()
+        monitor = Monitor(args)
+        
+        # Should not raise
+        monitor.stop_process()
+        
+        assert monitor.process is None
+
+    @patch("pymon.monitor.subprocess.Popen")
+    def test_restart_process(self, mock_popen):
+        """Should stop and start process on restart."""
+        mock_process = Mock()
+        mock_popen.return_value = mock_process
+        
+        args = self.create_args()
+        monitor = Monitor(args)
+        monitor.start_process()
+        monitor.restart_process()
+        
+        mock_process.terminate.assert_called_once()
+        assert mock_popen.call_count == 2
+


### PR DESCRIPTION
- Add config file support (`.pymonrc` / `pymon.json`) with CLI override precedence.
- Add `--version` / `-V` flag and expose `__version__ = "2.2.0"`.
- Add debounce option `--delay` (ms) to coalesce rapid file changes.
- Improve README (lean quickstart, core flags, config emphasis) and add `CHANGELOG.md`.
- Add full pytest suite (CLI, config, monitor, logger) and pytest config.
- Add GitHub Actions CI (Py 3.10–3.12) running tests on push/PR.
- Update packaging: dev extras (`.[dev]`), version bump in `setup.py`.